### PR TITLE
Add topic monitor plugin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
       - name: Setup
         run: | # qmlformat is in the dev tools
           sudo apt-get update && sudo apt-get install -y clang-format cppcheck libxml2-utils qt6-declarative-dev-tools
+          sudo ln -s /usr/lib/qt6/bin/qmlformat /usr/local/bin/qmlformat
 
       - name: Install and Run pre-commit
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,8 @@ jobs:
           fetch-depth: 0
 
       - name: Setup
-        run: |
-          sudo apt-get update && sudo apt-get install -y black clang-format cppcheck libxml2-utils
+        run: | # qmlformat is in the dev tools
+          sudo apt-get update && sudo apt-get install -y clang-format cppcheck libxml2-utils qt6-declarative-dev-tools
 
       - name: Install and Run pre-commit
         uses: pre-commit/action@v3.0.1

--- a/rqml_core/RQml/Elements/Caption.qml
+++ b/rqml_core/RQml/Elements/Caption.qml
@@ -1,7 +1,8 @@
 import QtQuick
 import QtQuick.Controls
+import "."
 
-Label {
+TruncatedLabel {
     font.pixelSize: 12
     opacity: 0.85
 }

--- a/rqml_core/RQml/Elements/EditMessageDialog.qml
+++ b/rqml_core/RQml/Elements/EditMessageDialog.qml
@@ -14,9 +14,12 @@
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import Ros2
+import RQml.Elements
+import RQml.Fonts
 import RQml.Utils
 
 Dialog {
@@ -24,8 +27,9 @@ Dialog {
 
     property alias message: messageModel.message
     property alias messageType: messageModel.messageType
+    property bool readonly: false
 
-    standardButtons: Dialog.Ok | Dialog.Cancel
+    standardButtons: readonly ? Dialog.Close : Dialog.Ok | Dialog.Cancel
     title: "Edit Message Content"
 
     ColumnLayout {
@@ -38,10 +42,12 @@ Dialog {
             Layout.fillWidth: true
 
             TabButton {
+                objectName: "editMessageDialogVisualTabButton"
                 text: qsTr("Visual")
             }
             TabButton {
-                text: qsTr("Text")
+                objectName: "editMessageDialogJsonTabButton"
+                text: qsTr("JSON")
             }
         }
         StackLayout {
@@ -53,6 +59,7 @@ Dialog {
                 id: messageContentEditor
                 Layout.fillHeight: true
                 Layout.fillWidth: true
+                readonly: control.readonly
 
                 model: MessageItemModel {
                     id: messageModel
@@ -64,22 +71,48 @@ Dialog {
                     }
                 }
             }
-            ScrollView {
+            ColumnLayout {
                 Layout.fillHeight: true
                 Layout.fillWidth: true
+                spacing: 8
 
-                TextArea {
-                    id: textArea
-                    anchors.fill: parent
-                    text: JSON.stringify(MessageUtils.toJavaScriptObject(control.message) ?? {}, null, 2)
+                ScrollView {
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
 
-                    onEditingFinished: {
-                        try {
-                            control.message = JSON.parse(text);
-                        } catch (e)
-                        // ignore parse errors
-                        {
+                    TextArea {
+                        id: textArea
+                        anchors.fill: parent
+                        objectName: "editMessageDialogJsonTextArea"
+                        readOnly: control.readonly
+                        text: JSON.stringify(MessageUtils.toJavaScriptObject(control.message) ?? {}, null, 2)
+                        wrapMode: TextEdit.NoWrap
+
+                        onEditingFinished: {
+                            if (control.readonly)
+                                return;
+                            try {
+                                control.message = JSON.parse(text);
+                            } catch (e)
+                            // ignore parse errors
+                            {
+                            }
                         }
+                    }
+                }
+                RowLayout {
+                    Layout.fillWidth: true
+
+                    Item {
+                        Layout.fillWidth: true
+                    }
+                    IconTextButton {
+                        id: copyJsonButton
+                        iconText: IconFont.iconCopy
+                        objectName: "editMessageDialogCopyJsonButton"
+                        text: qsTr("Copy JSON")
+
+                        onClicked: RQml.copyTextToClipboard(textArea.text)
                     }
                 }
             }

--- a/rqml_core/RQml/Elements/FuzzySelector.qml
+++ b/rqml_core/RQml/Elements/FuzzySelector.qml
@@ -32,6 +32,8 @@ import RQml.Utils
 Item {
     id: control
 
+    signal accepted(string text)
+
     implicitHeight: field.implicitHeight
     implicitWidth: field.implicitWidth
 
@@ -193,6 +195,7 @@ Item {
                 control.text = control.filteredItems[listView.currentIndex];
                 popup.close();
             }
+            control.accepted(control.text);
             event.accepted = true;
         }
 

--- a/rqml_core/RQml/Elements/Hint.qml
+++ b/rqml_core/RQml/Elements/Hint.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import "."
 
 Label {
     font.italic: true

--- a/rqml_core/RQml/Fonts/IconFont.qml
+++ b/rqml_core/RQml/Fonts/IconFont.qml
@@ -40,6 +40,7 @@ FontLoader {
     readonly property string iconLoad: "\uf56f"
     readonly property string iconMagnifyingGlassMinus: "\uf010"
     readonly property string iconMagnifyingGlassPlus: "\uf00e"
+    readonly property string iconMessage: "\uf075"
     readonly property string iconPause: "\uf04c"
     readonly property string iconPlay: "\uf04b"
     readonly property string iconRefresh: "\uf021"

--- a/rqml_core/test/tst_EditMessageDialog.qml
+++ b/rqml_core/test/tst_EditMessageDialog.qml
@@ -9,6 +9,19 @@ Item {
     height: 600
     width: 800
 
+    QtObject {
+        id: mockRqml
+
+        property string clipboard: ""
+
+        function resetClipboard() {
+            clipboard = "";
+        }
+        function copyTextToClipboard(text) {
+            clipboard = text;
+        }
+    }
+
     EditMessageDialog {
         id: dialog
         anchors.centerIn: parent
@@ -19,6 +32,12 @@ Item {
         width: 700
     }
     TestCase {
+        function initTestCase() {
+            TestContextBridge.setContextProperty("RQml", mockRqml);
+        }
+        function cleanupTestCase() {
+            TestContextBridge.setContextProperty("RQml", null);
+        }
 
         // ---- Helpers --------------------------------------------------------
         function findItemBy(item, predicate) {
@@ -69,6 +88,21 @@ Item {
             if (textArea !== null)
                 textArea.text = JSON.stringify(MessageUtils.toJavaScriptObject(dialog.message) || {}, null, 2);
         }
+        function test_copyJsonButtonCopiesViaUi() {
+            var tabBar = findTabBar();
+            var textArea = findTextArea();
+            var button = null;
+            tabBar.currentIndex = 1;
+            tryVerify(function () {
+                    button = findItemBy(dialog, function (c) {
+                            return c && c.objectName === "editMessageDialogCopyJsonButton" && c.visible;
+                        });
+                    return button !== null;
+                }, 1000, "Copy JSON button should be visible on the JSON tab");
+            RQml.resetClipboard();
+            mouseClick(button);
+            compare(RQml.clipboard, textArea.text, "Copy JSON button should copy the JSON text");
+        }
 
         // ---- Tests ----------------------------------------------------------
         function test_dualTabInterface() {
@@ -91,7 +125,9 @@ Item {
             compare(dialog.message.i32, prevI32, "invalid JSON must not corrupt the bound message");
         }
         function test_jsonEditUpdatesMessage() {
+            var tabBar = findTabBar();
             var textArea = findTextArea();
+            tabBar.currentIndex = 1;
             // Build a fresh JSON snapshot, mutate one field, write it back, and
             // simulate editingFinished — the dialog should update its message.
             var snapshot = JSON.parse(textArea.text);
@@ -101,7 +137,9 @@ Item {
             compare(dialog.message.i32, 314, "valid JSON edit should update the bound message");
         }
         function test_jsonSerializationFromMessage() {
+            var tabBar = findTabBar();
             var textArea = findTextArea();
+            tabBar.currentIndex = 1;
             verify(textArea !== null);
             // Empty TestMessage should serialise to a JSON object with the
             // expected fields.
@@ -114,6 +152,19 @@ Item {
             verify(parsed.hasOwnProperty("i32"), "JSON should contain i32 field");
             verify(parsed.hasOwnProperty("b"), "JSON should contain bool field");
         }
+        function test_readonly_mode() {
+            var tabBar = findTabBar();
+            var textArea = findTextArea();
+            dialog.readonly = true;
+            tabBar.currentIndex = 1;
+            compare(dialog.standardButtons, Dialog.Close, "Readonly dialog should use a close button");
+            compare(textArea.readOnly, true, "JSON text area should be readonly in readonly mode");
+            verify(dialog.standardButton(Dialog.Close) !== null, "Close button should be present in readonly mode");
+            verify(findItemBy(dialog, function (c) {
+                        return c && c.objectName === "editMessageDialogCopyJsonButton" && c.visible;
+                    }) !== null, "Copy JSON button should be visible in readonly mode");
+            dialog.readonly = false;
+        }
         function test_standardOkCancelButtons() {
             // Dialog.Ok | Dialog.Cancel — verify the standardButton accessor
             // returns valid buttons for both.
@@ -121,8 +172,10 @@ Item {
             verify(dialog.standardButton(Dialog.Cancel) !== null, "Cancel button should be present");
         }
         function test_visualEditPropagatesToText() {
+            var tabBar = findTabBar();
             var editor = findMessageContentEditor();
             var textArea = findTextArea();
+            tabBar.currentIndex = 0;
             verify(editor !== null);
             verify(editor.model !== null);
 

--- a/rqml_core/test/tst_EditMessageDialog.qml
+++ b/rqml_core/test/tst_EditMessageDialog.qml
@@ -14,14 +14,13 @@ Item {
 
         property string clipboard: ""
 
-        function resetClipboard() {
-            clipboard = "";
-        }
         function copyTextToClipboard(text) {
             clipboard = text;
         }
+        function resetClipboard() {
+            clipboard = "";
+        }
     }
-
     EditMessageDialog {
         id: dialog
         anchors.centerIn: parent
@@ -32,9 +31,6 @@ Item {
         width: 700
     }
     TestCase {
-        function initTestCase() {
-            TestContextBridge.setContextProperty("RQml", mockRqml);
-        }
         function cleanupTestCase() {
             TestContextBridge.setContextProperty("RQml", null);
         }
@@ -87,6 +83,9 @@ Item {
             var textArea = findTextArea();
             if (textArea !== null)
                 textArea.text = JSON.stringify(MessageUtils.toJavaScriptObject(dialog.message) || {}, null, 2);
+        }
+        function initTestCase() {
+            TestContextBridge.setContextProperty("RQml", mockRqml);
         }
         function test_copyJsonButtonCopiesViaUi() {
             var tabBar = findTabBar();

--- a/rqml_default_plugins/package.xml
+++ b/rqml_default_plugins/package.xml
@@ -15,12 +15,15 @@
   <exec_depend>control_msgs</exec_depend>
   <exec_depend>controller_manager_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>moveit_msgs</exec_depend>
+  <exec_depend>pal_statistics_msgs</exec_depend>
   <exec_depend>qml6-module-qt-labs-qmlmodels</exec_depend>
   <exec_depend>qml6-module-qtmultimedia</exec_depend>
   <exec_depend>qml6-module-qtquick-controls</exec_depend>
   <exec_depend>qml6-module-qtquick-dialogs</exec_depend>
   <exec_depend>qml6-module-qtquick-layouts</exec_depend>
   <exec_depend>qml6_ros2_plugin</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>tf2_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/rqml_default_plugins/qml/TopicMonitor.qml
+++ b/rqml_default_plugins/qml/TopicMonitor.qml
@@ -1,0 +1,333 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Ros2
+import RQml.Elements
+import RQml.Fonts
+
+Rectangle {
+    id: root
+
+    property var kddockwidgets_min_size: Qt.size(720, 360)
+    property string latestDialogTopic: ""
+
+    function addTopicEntry(topic) {
+        const normalizedTopic = String(topic ?? "").trim();
+        if (!Ros2.isValidTopic(normalizedTopic) || d.hasEntry(normalizedTopic))
+            return;
+        const type = d.resolveType(normalizedTopic);
+        if (!type)
+            return;
+        const entry = {
+            "topic": normalizedTopic,
+            "type": type,
+            "paused": false
+        };
+        const values = Array.from(context.monitoredTopics ?? []);
+        values.push(entry);
+        context.monitoredTopics = values;
+        monitorListModel.append(entry);
+    }
+    function openLatestMessageDialog(topic, type, message) {
+        latestDialogTopic = topic;
+        latestMessageDialog.messageType = type;
+        latestMessageDialog.message = message ? message : Ros2.createEmptyMessage(type);
+        latestMessageDialog.open();
+    }
+    function removeEntry(index) {
+        const values = Array.from(context.monitoredTopics ?? []);
+        values.splice(index, 1);
+        context.monitoredTopics = values;
+        monitorListModel.remove(index);
+    }
+    function updateEntry(index, update) {
+        const values = Array.from(context.monitoredTopics ?? []);
+        for (let key in update)
+            values[index][key] = update[key];
+        context.monitoredTopics = values;
+    }
+
+    anchors.fill: parent
+    color: palette.base
+
+    Component.onCompleted: {
+        if (context.monitoredTopics === undefined)
+            context.monitoredTopics = [];
+        for (let i = 0; i < context.monitoredTopics.length; ++i) {
+            const entry = context.monitoredTopics[i];
+            monitorListModel.append({
+                    "topic": entry.topic,
+                    "type": entry.type || d.resolveType(entry.topic),
+                    "paused": entry.paused ?? false
+                });
+        }
+    }
+
+    ListModel {
+        id: monitorListModel
+        dynamicRoles: true
+    }
+    EditMessageDialog {
+        id: latestMessageDialog
+        anchors.centerIn: Overlay.overlay
+        height: Math.min(600, (Overlay.overlay?.height ?? root.height) * 0.8)
+        modal: true
+        objectName: "topicMonitorMessageDialog"
+        readonly: true
+        title: latestDialogTopic ? qsTr("Latest Message: %1").arg(latestDialogTopic) : qsTr("Latest Message")
+        width: Math.min(800, (Overlay.overlay?.width ?? root.width) * 0.8)
+    }
+    QtObject {
+        id: d
+        function formatBandwidth(bytesPerSecond) {
+            const value = Number(bytesPerSecond ?? 0);
+            if (!isFinite(value) || value <= 0)
+                return "-";
+            if (value < 1024)
+                return value.toFixed(0) + " B/s";
+            if (value < 1024 * 1024)
+                return (value / 1024).toFixed(value < 10 * 1024 ? 1 : 0) + " KiB/s";
+            return (value / (1024 * 1024)).toFixed(1) + " MiB/s";
+        }
+        function formatFrequency(hz) {
+            const value = Number(hz ?? 0);
+            if (!isFinite(value) || value <= 0)
+                return "-";
+            if (value < 1)
+                return value.toFixed(2) + " Hz";
+            if (value < 10)
+                return value.toFixed(1) + " Hz";
+            return value.toFixed(0) + " Hz";
+        }
+        function hasEntry(topic) {
+            for (let i = 0; i < monitorListModel.count; ++i) {
+                if (monitorListModel.get(i).topic === topic)
+                    return true;
+            }
+            return false;
+        }
+        function resolveType(topic) {
+            const topicTypes = Ros2.getTopicTypes(topic);
+            return topicTypes.length > 0 ? topicTypes[0] : "";
+        }
+    }
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 8
+        spacing: 8
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 8
+
+            FuzzySelector {
+                id: topicSelector
+                function refresh() {
+                    const topics = Ros2.queryTopics().slice().sort();
+                    if (text) {
+                        const existingIndex = topics.indexOf(text);
+                        if (existingIndex !== -1)
+                            topics.splice(existingIndex, 1);
+                        topics.unshift(text);
+                    }
+                    model = topics;
+                }
+
+                Layout.fillWidth: true
+                objectName: "topicMonitorTopicSelector"
+                placeholderText: qsTr("Select a topic to monitor")
+
+                Component.onCompleted: refresh()
+                onAccepted: function (acceptedText) {
+                    root.addTopicEntry(acceptedText);
+                }
+            }
+            RefreshButton {
+                objectName: "topicMonitorRefreshButton"
+
+                onClicked: {
+                    animate = true;
+                    topicSelector.refresh();
+                    animate = false;
+                }
+            }
+            IconTextButton {
+                enabled: Ros2.isValidTopic(topicSelector.text) && !!d.resolveType(topicSelector.text) && !d.hasEntry(topicSelector.text)
+                iconText: IconFont.iconAdd
+                objectName: "topicMonitorAddButton"
+                text: qsTr("Add Topic")
+
+                onClicked: root.addTopicEntry(topicSelector.text)
+            }
+        }
+        Rectangle {
+            Layout.fillWidth: true
+            color: palette.alternateBase
+            implicitHeight: headerLayout.implicitHeight + 12
+            radius: 6
+
+            RowLayout {
+                id: headerLayout
+                anchors.fill: parent
+                anchors.margins: 6
+                spacing: 8
+
+                Item {
+                    Layout.preferredWidth: 40
+                }
+                Label {
+                    Layout.fillWidth: true
+                    font.bold: true
+                    text: qsTr("Topic")
+                }
+                Label {
+                    Layout.preferredWidth: 120
+                    font.bold: true
+                    horizontalAlignment: Text.AlignRight
+                    text: qsTr("Frequency")
+                }
+                Label {
+                    Layout.preferredWidth: 140
+                    font.bold: true
+                    horizontalAlignment: Text.AlignRight
+                    text: qsTr("Bandwidth")
+                }
+                Item {
+                    Layout.preferredWidth: 144
+                }
+            }
+        }
+        StackLayout {
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            currentIndex: monitorListModel.count === 0 ? 0 : 1
+
+            Hint {
+                horizontalAlignment: Text.AlignHCenter
+                text: qsTr("Add a topic to begin monitoring.")
+                verticalAlignment: Text.AlignVCenter
+            }
+            ListView {
+                id: monitorListView
+                Layout.fillHeight: true
+                Layout.fillWidth: true
+                clip: true
+                model: monitorListModel
+                objectName: "topicMonitorListView"
+                spacing: 8
+
+                ScrollBar.vertical: ScrollBar {
+                }
+                delegate: Rectangle {
+                    id: delegateRoot
+
+                    property real displayedBandwidth: 0
+                    property real displayedFrequency: 0
+                    required property int index
+                    required property var model
+
+                    color: index % 2 === 0 ? root.palette.base : root.palette.alternateBase
+                    implicitHeight: contentColumn.implicitHeight + 12
+                    radius: 6
+                    width: monitorListView.width
+
+                    Component.onCompleted: {
+                        displayedFrequency = topicSubscription.frequency;
+                        displayedBandwidth = topicSubscription.bandwidth;
+                    }
+
+                    ColumnLayout {
+                        id: contentColumn
+                        anchors.fill: parent
+                        anchors.margins: 6
+                        spacing: 0
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 8
+
+                            ColumnLayout {
+                                Layout.fillWidth: true
+                                spacing: 2
+
+                                Label {
+                                    Layout.fillWidth: true
+                                    elide: Text.ElideMiddle
+                                    font.bold: true
+                                    objectName: "topicMonitorTopicLabel_" + model.index
+                                    text: model.topic
+                                }
+                                Caption {
+                                    Layout.fillWidth: true
+                                    elide: Text.ElideRight
+                                    objectName: "topicMonitorTypeLabel_" + model.index
+                                    text: model.type
+                                }
+                            }
+                            Label {
+                                Layout.preferredWidth: 120
+                                horizontalAlignment: Text.AlignRight
+                                objectName: "topicMonitorFrequencyLabel_" + model.index
+                                text: d.formatFrequency(delegateRoot.displayedFrequency)
+                            }
+                            Label {
+                                Layout.preferredWidth: 140
+                                horizontalAlignment: Text.AlignRight
+                                objectName: "topicMonitorBandwidthLabel_" + model.index
+                                text: d.formatBandwidth(delegateRoot.displayedBandwidth)
+                            }
+                            IconButton {
+                                Layout.alignment: Qt.AlignVCenter
+                                objectName: "topicMonitorViewButton_" + model.index
+                                text: IconFont.iconMessage
+                                tooltipText: qsTr("View latest message")
+
+                                onClicked: root.openLatestMessageDialog(model.topic, model.type, topicSubscription.message)
+                            }
+                            IconButton {
+                                Layout.alignment: Qt.AlignVCenter
+                                objectName: "topicMonitorPauseButton_" + model.index
+                                text: model.paused ? IconFont.iconPlay : IconFont.iconPause
+                                tooltipText: model.paused ? qsTr("Resume topic") : qsTr("Pause topic")
+
+                                onClicked: {
+                                    const paused = !model.paused;
+                                    root.updateEntry(model.index, {
+                                            "paused": paused
+                                        });
+                                    model.paused = paused;
+                                }
+                            }
+                            IconButton {
+                                Layout.alignment: Qt.AlignVCenter
+                                objectName: "topicMonitorDeleteButton_" + model.index
+                                text: IconFont.iconTrash
+                                tooltipText: qsTr("Remove topic")
+
+                                onClicked: root.removeEntry(model.index)
+                            }
+                        }
+                    }
+                    Subscription {
+                        id: topicSubscription
+                        enabled: !model.paused
+                        messageType: model.type
+                        objectName: "topicMonitorSubscription_" + model.index
+                        throttleRate: 1
+                        topic: model.topic
+                    }
+                    Timer {
+                        interval: 500
+                        repeat: true
+                        running: !model.paused
+
+                        onTriggered: {
+                            delegateRoot.displayedFrequency = topicSubscription.frequency;
+                            delegateRoot.displayedBandwidth = topicSubscription.bandwidth;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/rqml_default_plugins/qml/TopicMonitor.qml
+++ b/rqml_default_plugins/qml/TopicMonitor.qml
@@ -171,41 +171,32 @@ Rectangle {
                 onClicked: root.addTopicEntry(topicSelector.text)
             }
         }
-        Rectangle {
+        RowLayout {
+            id: headerLayout
             Layout.fillWidth: true
-            border.color: palette.mid
-            border.width: 1
-            color: "transparent"
-            implicitHeight: headerLayout.implicitHeight + 12
+            Layout.margins: 6
             opacity: 0.6
-            radius: 4
+            spacing: 8
 
-            RowLayout {
-                id: headerLayout
-                anchors.fill: parent
-                anchors.margins: 8
-                spacing: 8
-
-                Label {
-                    Layout.fillWidth: true
-                    font.bold: true
-                    text: qsTr("Topic")
-                }
-                Label {
-                    Layout.preferredWidth: 80
-                    font.bold: true
-                    horizontalAlignment: Text.AlignHCenter
-                    text: qsTr("Frequency")
-                }
-                Label {
-                    Layout.preferredWidth: 80
-                    font.bold: true
-                    horizontalAlignment: Text.AlignHCenter
-                    text: qsTr("Bandwidth")
-                }
-                Item {
-                    Layout.preferredWidth: 120
-                }
+            Label {
+                Layout.fillWidth: true
+                font.bold: true
+                text: qsTr("Topic")
+            }
+            Label {
+                Layout.preferredWidth: 80
+                font.bold: true
+                horizontalAlignment: Text.AlignHCenter
+                text: qsTr("Frequency")
+            }
+            Label {
+                Layout.preferredWidth: 80
+                font.bold: true
+                horizontalAlignment: Text.AlignHCenter
+                text: qsTr("Bandwidth")
+            }
+            Item {
+                Layout.preferredWidth: 120
             }
         }
         StackLayout {

--- a/rqml_default_plugins/qml/TopicMonitor.qml
+++ b/rqml_default_plugins/qml/TopicMonitor.qml
@@ -8,7 +8,7 @@ import RQml.Fonts
 Rectangle {
     id: root
 
-    property var kddockwidgets_min_size: Qt.size(720, 360)
+    property var kddockwidgets_min_size: Qt.size(360, 360)
     property string latestDialogTopic: ""
 
     function addTopicEntry(topic) {
@@ -28,9 +28,9 @@ Rectangle {
         context.monitoredTopics = values;
         monitorListModel.append(entry);
     }
-    function openLatestMessageDialog(topic, type, message) {
+    function openLatestMessageDialog(topic, message) {
         latestDialogTopic = topic;
-        latestMessageDialog.messageType = type;
+        latestMessageDialog.messageType = message["#messageType"];
         latestMessageDialog.message = message ? message : Ros2.createEmptyMessage(type);
         latestMessageDialog.open();
     }
@@ -39,6 +39,17 @@ Rectangle {
         values.splice(index, 1);
         context.monitoredTopics = values;
         monitorListModel.remove(index);
+    }
+    function syncResolvedType(index, resolvedType) {
+        if (!resolvedType)
+            return;
+        const currentType = monitorListModel.get(index).type;
+        if (currentType === resolvedType)
+            return;
+        monitorListModel.setProperty(index, "type", resolvedType);
+        updateEntry(index, {
+                "type": resolvedType
+            });
     }
     function updateEntry(index, update) {
         const values = Array.from(context.monitoredTopics ?? []);
@@ -162,38 +173,38 @@ Rectangle {
         }
         Rectangle {
             Layout.fillWidth: true
-            color: palette.alternateBase
+            border.color: palette.mid
+            border.width: 1
+            color: "transparent"
             implicitHeight: headerLayout.implicitHeight + 12
-            radius: 6
+            opacity: 0.6
+            radius: 4
 
             RowLayout {
                 id: headerLayout
                 anchors.fill: parent
-                anchors.margins: 6
+                anchors.margins: 8
                 spacing: 8
 
-                Item {
-                    Layout.preferredWidth: 40
-                }
                 Label {
                     Layout.fillWidth: true
                     font.bold: true
                     text: qsTr("Topic")
                 }
                 Label {
-                    Layout.preferredWidth: 120
+                    Layout.preferredWidth: 80
                     font.bold: true
-                    horizontalAlignment: Text.AlignRight
+                    horizontalAlignment: Text.AlignHCenter
                     text: qsTr("Frequency")
                 }
                 Label {
-                    Layout.preferredWidth: 140
+                    Layout.preferredWidth: 80
                     font.bold: true
-                    horizontalAlignment: Text.AlignRight
+                    horizontalAlignment: Text.AlignHCenter
                     text: qsTr("Bandwidth")
                 }
                 Item {
-                    Layout.preferredWidth: 144
+                    Layout.preferredWidth: 120
                 }
             }
         }
@@ -225,6 +236,7 @@ Rectangle {
                     property real displayedFrequency: 0
                     required property int index
                     required property var model
+                    property string resolvedType: d.resolveType(model.topic)
 
                     color: index % 2 === 0 ? root.palette.base : root.palette.alternateBase
                     implicitHeight: contentColumn.implicitHeight + 12
@@ -234,6 +246,7 @@ Rectangle {
                     Component.onCompleted: {
                         displayedFrequency = topicSubscription.frequency;
                         displayedBandwidth = topicSubscription.bandwidth;
+                        root.syncResolvedType(model.index, resolvedType || topicSubscription.messageType);
                     }
 
                     ColumnLayout {
@@ -250,7 +263,7 @@ Rectangle {
                                 Layout.fillWidth: true
                                 spacing: 2
 
-                                Label {
+                                TruncatedLabel {
                                     Layout.fillWidth: true
                                     elide: Text.ElideMiddle
                                     font.bold: true
@@ -265,56 +278,73 @@ Rectangle {
                                 }
                             }
                             Label {
-                                Layout.preferredWidth: 120
-                                horizontalAlignment: Text.AlignRight
+                                Layout.fillWidth: false
+                                Layout.preferredWidth: 80
+                                horizontalAlignment: Text.AlignHCenter
                                 objectName: "topicMonitorFrequencyLabel_" + model.index
                                 text: d.formatFrequency(delegateRoot.displayedFrequency)
                             }
                             Label {
-                                Layout.preferredWidth: 140
-                                horizontalAlignment: Text.AlignRight
+                                Layout.fillWidth: false
+                                Layout.preferredWidth: 80
+                                horizontalAlignment: Text.AlignHCenter
                                 objectName: "topicMonitorBandwidthLabel_" + model.index
                                 text: d.formatBandwidth(delegateRoot.displayedBandwidth)
                             }
-                            IconButton {
-                                Layout.alignment: Qt.AlignVCenter
-                                objectName: "topicMonitorViewButton_" + model.index
-                                text: IconFont.iconMessage
-                                tooltipText: qsTr("View latest message")
+                            RowLayout {
+                                Layout.fillWidth: false
+                                Layout.preferredWidth: 120
+                                spacing: 0
 
-                                onClicked: root.openLatestMessageDialog(model.topic, model.type, topicSubscription.message)
-                            }
-                            IconButton {
-                                Layout.alignment: Qt.AlignVCenter
-                                objectName: "topicMonitorPauseButton_" + model.index
-                                text: model.paused ? IconFont.iconPlay : IconFont.iconPause
-                                tooltipText: model.paused ? qsTr("Resume topic") : qsTr("Pause topic")
-
-                                onClicked: {
-                                    const paused = !model.paused;
-                                    root.updateEntry(model.index, {
-                                            "paused": paused
-                                        });
-                                    model.paused = paused;
+                                // Spacer
+                                Item {
+                                    Layout.fillWidth: true
                                 }
-                            }
-                            IconButton {
-                                Layout.alignment: Qt.AlignVCenter
-                                objectName: "topicMonitorDeleteButton_" + model.index
-                                text: IconFont.iconTrash
-                                tooltipText: qsTr("Remove topic")
+                                IconButton {
+                                    Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+                                    enabled: !!topicSubscription.message
+                                    objectName: "topicMonitorViewButton_" + model.index
+                                    text: IconFont.iconMessage
+                                    tooltipText: qsTr("View latest message")
 
-                                onClicked: root.removeEntry(model.index)
+                                    onClicked: root.openLatestMessageDialog(model.topic, topicSubscription.message)
+                                }
+                                IconButton {
+                                    Layout.alignment: Qt.AlignVCenter
+                                    objectName: "topicMonitorPauseButton_" + model.index
+                                    text: model.paused ? IconFont.iconPlay : IconFont.iconPause
+                                    tooltipText: model.paused ? qsTr("Resume topic") : qsTr("Pause topic")
+
+                                    onClicked: {
+                                        const paused = !model.paused;
+                                        root.updateEntry(model.index, {
+                                                "paused": paused
+                                            });
+                                        model.paused = paused;
+                                    }
+                                }
+                                IconButton {
+                                    Layout.alignment: Qt.AlignVCenter
+                                    objectName: "topicMonitorDeleteButton_" + model.index
+                                    text: IconFont.iconTrash
+                                    tooltipText: qsTr("Remove topic")
+
+                                    onClicked: root.removeEntry(model.index)
+                                }
                             }
                         }
                     }
                     Subscription {
                         id: topicSubscription
                         enabled: !model.paused
-                        messageType: model.type
+                        messageType: resolvedType || model.type
                         objectName: "topicMonitorSubscription_" + model.index
                         throttleRate: 1
                         topic: model.topic
+
+                        onMessageTypeChanged: {
+                            root.syncResolvedType(model.index, messageType);
+                        }
                     }
                     Timer {
                         interval: 500

--- a/rqml_default_plugins/rqml_plugins.yaml.in
+++ b/rqml_default_plugins/rqml_plugins.yaml.in
@@ -59,3 +59,8 @@ plugins:
     group: "Introspection"
     path: "share/@PROJECT_NAME@/qml/TfTreeViewer.qml"
     single_instance: false
+  - id: default_plugins.topic_monitor
+    name: "Topic Monitor"
+    group: "Introspection"
+    path: "share/@PROJECT_NAME@/qml/TopicMonitor.qml"
+    single_instance: false

--- a/rqml_default_plugins/test/mock_classes.cpp
+++ b/rqml_default_plugins/test/mock_classes.cpp
@@ -1,6 +1,8 @@
 #include "mock_classes.hpp"
 #include "mock_ros2.hpp"
+#include <QDateTime>
 #include <QJSValue>
+#include <QJsonDocument>
 #include <QQmlEngine>
 #include <QRandomGenerator>
 #include <QTimer>
@@ -88,6 +90,16 @@ void MockSubscription::injectMessage( const QVariant &msg )
   // Wrap via babel_fish to ensure the message has proper structure and #messageType
   QJSValue wrapped = s_mockRos2->wrap( type_, msg );
   lastMessage_ = wrapped.toVariant();
+  const double nowSeconds = QDateTime::currentMSecsSinceEpoch() / 1000.0;
+  static QHash<const MockSubscription *, double> lastReceiveTime;
+  const double previousTime = lastReceiveTime.value( this, 0.0 );
+  if ( previousTime > 0.0 && nowSeconds > previousTime )
+    setFrequency( 1.0 / ( nowSeconds - previousTime ) );
+  lastReceiveTime.insert( this, nowSeconds );
+
+  const QByteArray jsonBytes =
+      QJsonDocument::fromVariant( lastMessage_ ).toJson( QJsonDocument::Compact );
+  setBandwidth( frequency_ * static_cast<double>( jsonBytes.size() ) );
   emit newMessage( lastMessage_ );
   emit messageChanged();
 }

--- a/rqml_default_plugins/test/mock_classes.hpp
+++ b/rqml_default_plugins/test/mock_classes.hpp
@@ -88,6 +88,8 @@ class MockSubscription : public QObject
   Q_PROPERTY( int queueSize READ queueSize WRITE setQueueSize NOTIFY queueSizeChanged )
   Q_PROPERTY( qml6_ros2_plugin::QoSWrapper qos READ qos WRITE setQos NOTIFY qosChanged )
   Q_PROPERTY( QVariant message READ message NOTIFY messageChanged )
+  Q_PROPERTY( double frequency READ frequency WRITE setFrequency NOTIFY frequencyChanged )
+  Q_PROPERTY( double bandwidth READ bandwidth WRITE setBandwidth NOTIFY bandwidthChanged )
   Q_PROPERTY( bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged )
   Q_PROPERTY( bool subscribed READ subscribed NOTIFY subscribedChanged )
 public:
@@ -131,6 +133,24 @@ public:
 
   QVariant message() const { return lastMessage_; }
 
+  double frequency() const { return frequency_; }
+  void setFrequency( double value )
+  {
+    if ( qFuzzyCompare( frequency_, value ) )
+      return;
+    frequency_ = value;
+    emit frequencyChanged();
+  }
+
+  double bandwidth() const { return bandwidth_; }
+  void setBandwidth( double value )
+  {
+    if ( qFuzzyCompare( bandwidth_, value ) )
+      return;
+    bandwidth_ = value;
+    emit bandwidthChanged();
+  }
+
   bool enabled() const { return enabled_; }
   void setEnabled( bool e )
   {
@@ -152,6 +172,8 @@ public:
 signals:
   void newMessage( QVariant msg );
   void messageChanged();
+  void frequencyChanged();
+  void bandwidthChanged();
   void qosChanged();
   void topicChanged();
   void messageTypeChanged();
@@ -165,6 +187,8 @@ private:
   int throttleRate_ = 0, queueSize_ = 10;
   qml6_ros2_plugin::QoSWrapper qos_;
   QVariant lastMessage_;
+  double frequency_ = 0.0;
+  double bandwidth_ = 0.0;
   bool enabled_ = true, subscribed_ = true;
 };
 

--- a/rqml_default_plugins/test/tst_TopicMonitor.qml
+++ b/rqml_default_plugins/test/tst_TopicMonitor.qml
@@ -1,0 +1,152 @@
+import QtQuick
+import QtTest
+import Ros2
+
+Item {
+    id: root
+
+    property var context: contextObj
+    property var plugin: pluginLoader.item
+
+    function find(name) {
+        return helpers.findChild(root, name);
+    }
+
+    height: 768
+    width: 1024
+
+    QtObject {
+        id: contextObj
+
+        property var monitoredTopics: []
+    }
+    Utils {
+        id: helpers
+    }
+    Loader {
+        id: pluginLoader
+        function reload() {
+            source = "";
+            source = "../qml/TopicMonitor.qml";
+        }
+
+        anchors.fill: parent
+    }
+    TestCase {
+        function init() {
+            Ros2.reset();
+            Ros2.registerTopic("/test_topic", "std_msgs/msg/String");
+            contextObj.monitoredTopics = [];
+            pluginLoader.reload();
+            tryVerify(function () {
+                    return pluginLoader.status === Loader.Ready;
+                }, 2000, "Loader should be ready");
+            wait(100);
+        }
+        function test_add_and_remove_topic() {
+            var topicSelector = find("topicMonitorTopicSelector");
+            var addButton = find("topicMonitorAddButton");
+            var listView = find("topicMonitorListView");
+            verify(topicSelector !== null);
+            verify(addButton !== null);
+            verify(listView !== null);
+            topicSelector.text = "/test_topic";
+            tryVerify(function () {
+                    return addButton.enabled;
+                }, 1000, "Add button should enable for a known topic");
+            mouseClick(addButton);
+            tryCompare(listView, "count", 1, 2000, "Should have one monitored topic");
+            compare(contextObj.monitoredTopics.length, 1, "Context should persist monitored topics");
+            compare(contextObj.monitoredTopics[0].topic, "/test_topic");
+            compare(contextObj.monitoredTopics[0].type, "std_msgs/msg/String");
+            var deleteButton = null;
+            tryVerify(function () {
+                    deleteButton = find("topicMonitorDeleteButton_0");
+                    return deleteButton !== null;
+                }, 2000, "Delete button should exist");
+            mouseClick(deleteButton);
+            tryCompare(listView, "count", 0, 2000, "Topic should be removed");
+            compare(contextObj.monitoredTopics.length, 0, "Context should be updated after removal");
+        }
+        function test_enter_adds_topic() {
+            var topicSelector = find("topicMonitorTopicSelector");
+            var listView = find("topicMonitorListView");
+            verify(topicSelector !== null);
+            verify(listView !== null);
+            topicSelector.text = "/test_topic";
+            tryCompare(topicSelector, "currentIndex", 0, 1000, "Topic should be selected");
+            mouseClick(topicSelector);
+            keyClick(Qt.Key_Return);
+            tryCompare(listView, "count", 1, 2000, "Pressing enter should add the topic");
+            compare(contextObj.monitoredTopics.length, 1);
+        }
+        function test_pause_and_view_latest_message() {
+            var topicSelector = find("topicMonitorTopicSelector");
+            var addButton = find("topicMonitorAddButton");
+            topicSelector.text = "/test_topic";
+            tryVerify(function () {
+                    return addButton.enabled;
+                }, 1000);
+            mouseClick(addButton);
+            var sub = null;
+            tryVerify(function () {
+                    sub = Ros2.findSubscription("/test_topic");
+                    return sub !== null;
+                }, 2000, "Subscription should be created");
+            var msg = Ros2.createEmptyMessage("std_msgs/msg/String");
+            msg.data = "hello monitor";
+            sub.injectMessage(msg);
+            sub.frequency = 8.5;
+            sub.bandwidth = 2048;
+            var frequencyLabel = null;
+            var bandwidthLabel = null;
+            tryVerify(function () {
+                    frequencyLabel = find("topicMonitorFrequencyLabel_0");
+                    bandwidthLabel = find("topicMonitorBandwidthLabel_0");
+                    return frequencyLabel !== null && bandwidthLabel !== null;
+                }, 2000);
+            tryCompare(frequencyLabel, "text", "8.5 Hz", 2500);
+            tryCompare(bandwidthLabel, "text", "2.0 KiB/s", 2500);
+            var pauseButton = find("topicMonitorPauseButton_0");
+            verify(pauseButton !== null, "Pause button should exist");
+            mouseClick(pauseButton);
+            tryCompare(contextObj.monitoredTopics[0], "paused", true, 2000, "Paused state should persist");
+            compare(sub.enabled, false, "Subscription should be disabled when paused");
+            sub.frequency = 0;
+            sub.bandwidth = 0;
+            wait(1200);
+            compare(frequencyLabel.text, "8.5 Hz", "Paused rows should keep the last displayed frequency");
+            compare(bandwidthLabel.text, "2.0 KiB/s", "Paused rows should keep the last displayed bandwidth");
+            var viewButton = find("topicMonitorViewButton_0");
+            verify(viewButton !== null, "View button should exist");
+            mouseClick(viewButton);
+            var dialog = null;
+            var jsonTextArea = null;
+            tryVerify(function () {
+                    dialog = find("topicMonitorMessageDialog");
+                    return dialog !== null && dialog.visible;
+                }, 3000, "Latest-message dialog should be visible");
+            tryVerify(function () {
+                    return dialog.message && dialog.message.data === "hello monitor";
+                }, 2000, "Readonly dialog should show the latest message");
+            var jsonTabButton = find("editMessageDialogJsonTabButton");
+            verify(jsonTabButton !== null, "JSON tab button should exist");
+            mouseClick(jsonTabButton);
+            tryVerify(function () {
+                    jsonTextArea = find("editMessageDialogJsonTextArea");
+                    return jsonTextArea !== null && jsonTextArea.text.indexOf("\"data\": \"hello monitor\"") !== -1;
+                }, 3000, "JSON view should show the latest message");
+            var copyJsonButton = find("editMessageDialogCopyJsonButton");
+            verify(copyJsonButton !== null);
+            RQml.resetClipboard();
+            mouseClick(copyJsonButton);
+            compare(RQml.clipboard, jsonTextArea.text, "Copy JSON button should copy the readonly JSON");
+        }
+        function test_plugin_loads() {
+            verify(plugin !== null, "TopicMonitor plugin should load");
+        }
+
+        name: "TopicMonitorTest"
+        when: windowShown
+    }
+}

--- a/rqml_default_plugins/test/tst_TopicMonitor.qml
+++ b/rqml_default_plugins/test/tst_TopicMonitor.qml
@@ -145,6 +145,48 @@ Item {
         function test_plugin_loads() {
             verify(plugin !== null, "TopicMonitor plugin should load");
         }
+        function test_restored_topic_syncs_live_type() {
+            contextObj.monitoredTopics = [{
+                    "topic": "/test_topic",
+                    "type": "std_msgs/msg/Bool",
+                    "paused": false
+                }];
+            pluginLoader.reload();
+            tryVerify(function () {
+                    return pluginLoader.status === Loader.Ready;
+                }, 2000, "Loader should be ready after restoring a topic");
+            var listView = find("topicMonitorListView");
+            verify(listView !== null);
+            tryCompare(listView, "count", 1, 2000, "Restored topic should be shown");
+            var sub = null;
+            tryVerify(function () {
+                    sub = Ros2.findSubscription("/test_topic");
+                    return sub !== null;
+                }, 2000, "Subscription should be created for restored topic");
+            tryCompare(sub, "messageType", "std_msgs/msg/String", 2000, "Subscription should resolve the live topic type");
+            tryCompare(contextObj.monitoredTopics[0], "type", "std_msgs/msg/String", 2000, "Persisted entry should self-heal to the live topic type");
+            var typeLabel = null;
+            tryVerify(function () {
+                    typeLabel = find("topicMonitorTypeLabel_0");
+                    return typeLabel !== null;
+                }, 2000, "Type label should exist");
+            tryCompare(typeLabel, "text", "std_msgs/msg/String", 2000, "Visible row type should update to the live topic type");
+            var msg = Ros2.createEmptyMessage("std_msgs/msg/String");
+            msg.data = "restored message";
+            sub.injectMessage(msg);
+            var viewButton = find("topicMonitorViewButton_0");
+            verify(viewButton !== null, "View button should exist for restored topic");
+            mouseClick(viewButton);
+            var dialog = null;
+            tryVerify(function () {
+                    dialog = find("topicMonitorMessageDialog");
+                    return dialog !== null && dialog.visible;
+                }, 3000, "Latest-message dialog should be visible for restored topic");
+            compare(dialog.messageType, "std_msgs/msg/String", "Dialog should use the live resolved topic type");
+            tryVerify(function () {
+                    return dialog.message && dialog.message.data === "restored message";
+                }, 2000, "Dialog should show the restored topic's latest message");
+        }
 
         name: "TopicMonitorTest"
         when: windowShown


### PR DESCRIPTION
Adds a topic monitor plugin that subscribes to a list of topics and measures bandwidth and frequency.
The latest message on the topic can be viewed as a tree and as JSON.
 
<img width="657" height="654" alt="image" src="https://github.com/user-attachments/assets/b92eceb9-b445-40b0-974d-1ae2554373e1" />
