### PR TITLE
destroy plugin on close

### DIFF
--- a/rqml_core/src/plugin_manager.cpp
+++ b/rqml_core/src/plugin_manager.cpp
@@ -174,9 +174,12 @@ KDDockWidgets::QtQuick::DockWidget *PluginManager::createPlugin( const QString &
 
   auto *dw = new KDDockWidgets::QtQuick::DockWidget( instance->unique_name_ );
   dw->setTitle( it_plugin->name_ );
+  dw->enableAttribute( Qt::WA_DeleteOnClose );
   auto *context = new QQmlContext( engine_->rootContext() );
   context->setContextObject( instance );
   dw->setGuestItem( "file://" + it_plugin->path_, context );
+  connect( dw, &KDDockWidgets::QtQuick::DockWidget::isOpenChanged, this,
+           &PluginManager::onOpenChanged );
   dw->open();
   return dw;
 }


### PR DESCRIPTION
I noticed when developing a plugin that Component.onDestruction would not be called on close when the plugin was opened in the menu through the PluginManager::createPlugin code path, but would be when the plugin was created by restoring a layout from an existing config.

Adding these two lines of code puts PluginManager::createPlugin in alignment with PluginManager::factoryFn and creates the behavior I would expect when plugins are closed.