### PR TITLE
TopicMonitor issue: TypeError: Cannot read property '#messageType' of undefined

### DIFF
--- a/rqml_default_plugins/qml/TopicMonitor.qml
+++ b/rqml_default_plugins/qml/TopicMonitor.qml
@@ -293,7 +293,7 @@ Rectangle {
                                 }
                                 IconButton {
                                     Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
-                                    enabled: !!topicSubscription.message
+                                    enabled: !!topicSubscription.message && !model.paused
                                     objectName: "topicMonitorViewButton_" + model.index
                                     text: IconFont.iconMessage
                                     tooltipText: qsTr("View latest message")


### PR DESCRIPTION
Sorry to report an issue/open a pull request shortly before the Lyrical freeze.

During testing/playing around with the latest version (3.26.41) i encountered a small issue in the TopicMonitor plugin that I could fix.

TopicMonitor.qml:33: TypeError: Cannot read property '#messageType' of undefined

Issue occurs when monitoring a topic is paused and  the user clicks "View latest message".